### PR TITLE
Fix memory leak

### DIFF
--- a/lib/remote_resource/base.rb
+++ b/lib/remote_resource/base.rb
@@ -16,7 +16,7 @@ module RemoteResource
     def initialize(**args)
       @scope = args
       create_attributes(self)
-      AttributeMethodAttacher.new(self.class).attach_to(self.class)
+      AttributeMethodAttacher.new(self.class).attach_to(self.singleton_class)
     end
 
     def client

--- a/lib/remote_resource/version.rb
+++ b/lib/remote_resource/version.rb
@@ -1,3 +1,3 @@
 module RemoteResource
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
After running this in production for some time, I found that sidekiq workers were running out of memory and crashing. 

Finding memory leaks is hard, but I found the method described in https://gist.github.com/krasnoukhov/a036bb7bc8c8416e9481 to be extremely helpful.

The small change in https://github.com/mkcode/remote-resource/commit/776a0646ba1d962c67f518e6fb7e41b62330e3e9, using the object's singleton_class rather than class, brings the retained memory down to almost nothing.

That small change caused a race condition that a ruby vm crash. All C methods in ruby (which `module_eval` is) are consider to not safe. The fix for this is ripped from ActiveRecord, and how they create their attribute methods: https://github.com/rails/rails/blob/b6429b871ff8b73ebd10076ead6ed2c1f651da86/activerecord/lib/active_record/attribute_methods.rb#L55-L66

I was able to reliable test the thread safety be bringing sidekiq's concurrency up to 50 (the recommended max). It failed overtime before https://github.com/mkcode/remote-resource/commit/ce47626ce978a120be38d7920a61d6be5ff16f7d, and I could not get it fail after.
